### PR TITLE
Bumped Spark dependency to 1.4.1 to circumvent broken jar from jcenter

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,7 +46,7 @@ object WorkshopBuild extends Build {
       "org.scalanlp" %% "breeze-natives" % "0.11.2",
       "com.quantifind" %% "wisp" % "0.0.4",
       "org.scalatest"     %  "scalatest_2.10"  %  "2.2.1" % "test",
-      "org.apache.spark" %%  "spark-core"  %  "1.4.0"
+      "org.apache.spark" %%  "spark-core"  %  "1.4.1"
     ),
     shellPrompt <<= name(name => { state: State =>
       object devnull extends ProcessLogger {


### PR DESCRIPTION
1.4.0 jar continues to be broken and 1.4.1 worked just fine. 

Discussion: http://stackoverflow.com/questions/32030794/error-while-loading-root-error-accessing-ivy2-cache-org-apache-spark-spark-c
